### PR TITLE
Runtime plugin instance evaluation + more featureful toolbar

### DIFF
--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/manager.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/manager.py
@@ -30,7 +30,6 @@ from gi.repository import Gimp  # noqa
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # noqa
-from gi.repository import Gtk # noqa
 
 gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/manager.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/manager.py
@@ -3,6 +3,7 @@ import os
 import configparser
 import window
 import threading
+from toolbar import ProjectToolbar
 
 # autopep8 off
 import gi  # noqa
@@ -166,6 +167,12 @@ class PictonodeManager(metaclass=SingletonConstruction):
         pass
 
     # we should disambiguate between loaded local projects and unloaded
+
+
+    @threadsafe
+    def set_current_project(self, prjname):
+        if prjname in self.local_projects.keys():
+            print(prjname)
 
     @threadsafe
     def __add_local_project(self, image):

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/pictonode.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/pictonode.py
@@ -172,7 +172,7 @@ class Pictonode (Gimp.PlugIn):
                 register_instance_parasite()
 
             else:
-                from utils import pid_exists
+                from utils import pid_exists, get_ppid
 
                 suspect = bytes(parasite.get_data()).decode("utf-8")
 
@@ -180,15 +180,17 @@ class Pictonode (Gimp.PlugIn):
 
                     # There's a chance that the registered process id is this
                     # process id, even though this process isn't who registered
-                    # that instance in the parasite
+                    # that instance in the parasite, or the registered process
+                    # id that exists isn't associated with GIMP
 
-                    if int(os.getpid()) == int(suspect):
+                    if (int(os.getpid()) == int(suspect)) or (
+                            int(Gimp.getpid()) != int(get_ppid(suspect))):
 
                         # If so, we know to recycle the parasite because it
                         # wasn't us
 
                         recycle_instance_parasite()
-                        
+
                     else:
                         msg = _("Procedure '{}' is already running!.").format(
                             procedure.get_name())

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/pictonode.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/pictonode.py
@@ -186,8 +186,15 @@ class Pictonode (Gimp.PlugIn):
                     if (int(os.getpid()) == int(suspect)) or (
                             int(Gimp.getpid()) != int(get_ppid(suspect))):
 
-                        # If so, we know to recycle the parasite because it
-                        # wasn't us
+                        # There's one deeper edge case where the suspect is a
+                        # persistent process launched by GIMP. This is highly
+                        # unlikely due to GIMP procedure nature, however it
+                        # could still happen. In this scenario restarting GIMP
+                        # would be sufficient. A solution could be to also
+                        # register GIMPS pid in the parasite to check for this,
+                        # however the flatpak version of GIMP would prove an
+                        # issue for this as it runs in its own pid namespace
+                        # (its pid will always be 2)
 
                         recycle_instance_parasite()
 

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/pictonode.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/pictonode.py
@@ -236,7 +236,7 @@ class Pictonode (Gimp.PlugIn):
 
         else:
             raise Exception(">:(")
-        print(get_pid_timestamp(Gimp.getpid()))
+        
         return procedure.new_return_values(
             Gimp.PDBStatusType.SUCCESS, GLib.Error())
 

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/pictonode.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/pictonode.py
@@ -218,7 +218,7 @@ class Pictonode (Gimp.PlugIn):
                     else:
                         msg = _("Procedure '{}' is already running!").format(
                             procedure.get_name())
-                        msg += "\nInitiated at: " + timestamp
+                        msg += "\nInitiated at: " + get_pid_timestamp(int(suspect))
                         error = GLib.Error.new_literal(
                             Gimp.PlugIn.error_quark(), msg, 0)
                         return procedure.new_return_values(

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/toolbar.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/toolbar.py
@@ -1,0 +1,104 @@
+import os
+import configparser
+import window
+import threading
+
+# autopep8 off
+import gi # noqa
+gi.require_version("GIRepository", "2.0")
+from gi.repository import GIRepository  # noqa
+
+GIRepository.Repository.prepend_search_path(
+    os.path.realpath(
+        os.path.dirname(
+            os.path.abspath(__file__)) +
+        "/introspection"))
+
+GIRepository.Repository.prepend_library_path(
+    os.path.realpath(
+        os.path.dirname(
+            os.path.abspath(__file__)) +
+        "/libs"))
+
+gi.require_version("GtkNodes", "0.1")
+from gi.repository import GtkNodes  # noqa
+
+gi.require_version('Gimp', '3.0')
+from gi.repository import Gimp  # noqa
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk # noqa
+
+gi.require_version("Gdk", "3.0")
+from gi.repository import Gdk
+
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio  # noqa
+
+gi.require_version("GObject", "2.0")
+from gi.repository import GObject # noqa
+from gi.repository.GdkPixbuf import Pixbuf # noqa
+
+class ProjectToolbar(Gtk.Window):
+
+    def __init__(self):
+        super().__init__()
+        
+        self.set_default_size(200, 200)
+        self.hints = Gdk.Geometry()
+        self.hints.min_width = 128
+        self.hints.max_width = 256
+        self.hints.min_height = 192
+        self.hints.max_height = 512
+        self.__set_size_hints()
+
+        self.liststore = Gtk.ListStore(Pixbuf, str)
+        self.iconview = Gtk.IconView.new()
+        self.iconview.set_activate_on_single_click(True)
+        self.iconview.set_selection_mode(Gtk.SelectionMode.BROWSE)
+
+        self.iconview.set_model(self.liststore)
+        self.iconview.set_pixbuf_column(0)
+        self.iconview.set_text_column(1)
+        self.iconview.set_item_width(64)
+        self.add(self.iconview)
+
+        self._projects = []
+
+        self.iconview.connect("selection-changed", self.icon_clicked)
+        self.init = True
+
+        self.connect("destroy", Gtk.main_quit)
+
+    def icon_clicked(self, widget: Gtk.IconView):
+        from manager import PictonodeManager
+
+        if len(widget.get_selected_items()) != 0:
+            PictonodeManager().set_current_project(self.liststore[widget.get_selected_items()[0]][1])
+
+    def add_project(self, prjname: str, pixbuf: Pixbuf) -> None:
+        """Store the prjname aligned with itself in the list store so we have easy removal."""
+        self._projects.append(prjname)
+        self.liststore.append([pixbuf, prjname])
+        
+        if self.init:
+            self.iconview.select_path(Gtk.TreePath.new_first())
+            self.init = False
+
+    def remove_project(self, prjname: str) -> None:
+        remove_index = self._projects.index(prjname)
+        self._projects.pop(remove_index)
+        self.liststore.pop(remove_index)
+    
+    def update_project_thumbnail(self, prjname: str, pixbuf: Pixbuf) -> None:
+        update_index = self._projects.index(prjname)
+        self.liststore[update_index] = [pixbuf, prjname]
+
+    def update_project_name(self, oldprjname: str, newprjname: str) -> None:
+        update_index = self._projects.index(oldprjname)
+        self._projects[update_index] = newprjname
+        pixbuf = self.liststore[update_index][0]
+        self.liststore[update_index] = [pixbuf, newprjname]
+
+    def __set_size_hints(self) -> None:
+        self.set_geometry_hints(None, self.hints, Gdk.WindowHints.MAX_SIZE | Gdk.WindowHints.MIN_SIZE)

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/utils.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/utils.py
@@ -12,6 +12,16 @@ if os.name == 'posix':
             return True
         return False
 
+    # https://stackoverflow.com/a/70463176 Get ppid without psutil dependency
+
+    def get_ppid(pid: int) -> int:
+      # Read /proc/<pid>/status and look for the line `PPid:\t120517\n`
+        with open(f"/proc/{pid}/status", encoding="ascii") as f:
+            for line in f.readlines():
+                if line.startswith("PPid:\t"):
+                    return int(line[6:])
+        raise Exception(f"No PPid line found in /proc/{pid}/status")
+
 # Using ctypes for win32 pid introspection is tricky and has many edge cases, see:
 # https://stackoverflow.com/a/17645146 & https://stackoverflow.com/a/23409343
 
@@ -29,3 +39,6 @@ elif os.name == 'nt':
             return False
         else:
             return True
+
+    def get_ppid(pid: int) -> int:
+        raise Exception("<nt>get_ppid() not implemented")

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/utils.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/utils.py
@@ -24,8 +24,10 @@ if os.name == 'posix':
     
     def get_pid_timestamp(pid: int) -> str:
         import subprocess
-        print(pid)
-        proc = subprocess.check_output(["ps", "-p", f"{pid}", "-o", "lstart="])
+        try:
+            proc = subprocess.check_output(["ps", "-p", f"{pid}", "-o", "lstart="])
+        except Exception as e:
+            raise e
         return proc.decode('utf-8')
     
 # Using ctypes for win32 pid introspection is tricky and has many edge cases, see:
@@ -48,3 +50,6 @@ elif os.name == 'nt':
 
     def get_ppid(pid: int) -> int:
         raise Exception("<nt>get_ppid() not implemented")
+    
+    def get_pid_timestamp(pid: int) ->str:
+        raise Exception("<nt>get_pid_timestamp() not implemented")

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/utils.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/utils.py
@@ -21,7 +21,13 @@ if os.name == 'posix':
                 if line.startswith("PPid:\t"):
                     return int(line[6:])
         raise Exception(f"No PPid line found in /proc/{pid}/status")
-
+    
+    def get_pid_timestamp(pid: int) -> str:
+        import subprocess
+        print(pid)
+        proc = subprocess.check_output(["ps", "-p", f"{pid}", "-o", "lstart="])
+        return proc.decode('utf-8')
+    
 # Using ctypes for win32 pid introspection is tricky and has many edge cases, see:
 # https://stackoverflow.com/a/17645146 & https://stackoverflow.com/a/23409343
 

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/utils.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/utils.py
@@ -1,0 +1,31 @@
+import os
+
+if os.name == 'posix':
+    def pid_exists(pid: int) -> bool:
+        import errno
+        if pid > 0:
+            try:
+                os.kill(pid, 0)
+            except OSError as e:
+                # Permission error confirms the process exists.
+                return e.errno == errno.EPERM
+            return True
+        return False
+
+# Using ctypes for win32 pid introspection is tricky and has many edge cases, see:
+# https://stackoverflow.com/a/17645146 & https://stackoverflow.com/a/23409343
+
+# We can circumvent this through the tasklist shell command, and parsing its output:
+# https://stackoverflow.com/a/63497262
+
+elif os.name == 'nt':
+    def pid_exists(pid: int) -> bool:
+        import re
+        import subprocess
+        out = subprocess.check_output(
+            ["tasklist", "/fi", f"PID eq {pid}"]).strip()
+
+        if re.search(b'No tasks', out, re.IGNORECASE):
+            return False
+        else:
+            return True


### PR DESCRIPTION
### Runtime plugin instance evaluation
Essentially we want to constrain our plugin to just one instance per gimp session. This pull solves this by using a persistent `Gimp.Parasite` registering itself with its data being the registering plugin process id and the timestamp of its parent process. This wouldn't be necessary if the GIMP API provided a parasite that was only persistent for a session, as the temporary parasite it does provide can easily be invalidated by user flow (like saving anything!?!?). I added a `utils.py` with methods to inspect pids and their timestamps in a way that:

#### Posix
1. Does not rely on 3rd party modules
2. Works for most posix environments and doesn't rely on the presence of systemd (Looking at you WSL)

Windows implementations of these utils aren't finished being implemented, but that shouldn't be a blocker at the moment.

### Toolbar
The toolbar has an api for adding projects, removing projects, selecting projects, and refreshing project thumbnails, but is still a WIP, but it's functional in its current form. 