### PR TITLE
Update flatpak-install to accept a plugindir arg

### DIFF
--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/scripts/Linux/install-flatpak.sh
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/scripts/Linux/install-flatpak.sh
@@ -6,13 +6,22 @@ then
     python3 ../GtkNodes/setup_gtknodes.py
 fi
 
+if [ "$1" == "" ]
+then
+   plugins_dir=~/.var/app/org.gimp.GIMP/config/GIMP/2.99/plug-ins
+else
+   plugins_dir=$1
+   mkdir $plugins_dir
+   chmod 777 $plugins_dir
+fi
+
 ontario=../../../../../backend/ontario/ontario
-plugins_dir=~/plug-ins
 
 cp -r ../../pictonode $plugins_dir
 cp -r ./output/introspection $plugins_dir/pictonode
 cp -r ./output/libs $plugins_dir/pictonode
 cp -r $ontario $plugins_dir/pictonode
+
 chmod -R 777 $plugins_dir/pictonode
 
 popd


### PR DESCRIPTION
looks like this got messed up in a recent pull, but took it as opportunity to just make it better