### PR TITLE
segfault fix + manager is userstate aware

### DIFF
--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/custom_nodes.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/custom_nodes.py
@@ -96,9 +96,6 @@ class ImgSrcNode(CustomNode):
         # create dropdown with layers
         self.list_store = Gtk.ListStore(str, int)
         self.list_store.append(["Select a Layer", -1])
-        for i, d in enumerate(self.layers):
-            self.list_store.append(["Layer: " + d.get_name(), i])
-            print("Layer: ", d)
 
         self.layer_combobox = Gtk.ComboBox.new_with_model_and_entry(self.list_store)
         self.layer_combobox.set_margin_top(20)
@@ -116,7 +113,18 @@ class ImgSrcNode(CustomNode):
             label, GtkNodes.NodeSocketIO.SOURCE)
         self.node_socket_output.connect(
             "socket_connect", self.node_socket_connect)
+        
+    def set_layers(self, layers):
+        self.layers = layers
+        #placeholder setting until we know what we want to do
+        self.list_store.clear()
+        self.list_store.append(["Select a Layer", -1])
+        self.layer_combobox.set_active(0)
 
+        for i, d in enumerate(self.layers):
+            self.list_store.append(["Layer: " + d.get_name(), i])
+            print("Layer: ", d)
+        
     def change_layer(self, combo):
         iter = combo.get_active_iter()
         if iter is not None:

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/pictonode.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/pictonode.py
@@ -132,11 +132,12 @@ class Pictonode (Gimp.PlugIn):
                                             Gimp.PDBProcType.PLUGIN,
                                             self.run, None)
 
-        procedure.set_image_types("RGB*, GRAY*")
+        procedure.set_image_types("*")
         procedure.set_sensitivity_mask(Gimp.ProcedureSensitivityMask.DRAWABLE |
                                        Gimp.ProcedureSensitivityMask.DRAWABLES |
-                                       Gimp.ProcedureSensitivityMask.NO_DRAWABLES)
-
+                                       Gimp.ProcedureSensitivityMask.NO_DRAWABLES |
+                                       Gimp.ProcedureSensitivityMask.NO_IMAGE )
+        
         procedure.set_documentation(_("Pictonode"),
                                     _("Launches Pictonode plugin"),
                                     name)

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/toolbar.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/toolbar.py
@@ -67,7 +67,6 @@ class ProjectToolbar(Gtk.Window):
         self.init = True
 
         self.connect("destroy", Gtk.main_quit)
-        self.show_all()
 
     def icon_clicked(self, widget: Gtk.IconView):
         if self.mode != "Debug":
@@ -78,19 +77,22 @@ class ProjectToolbar(Gtk.Window):
 
     def add_project(self, prjname: str, pixbuf: Pixbuf) -> None:
         """Store the prjname aligned with itself in the list store so we have easy removal."""
-        self._projects.append(prjname)
-        self.liststore.append([pixbuf, prjname])
-        self.resize(64, len(self._projects) * 64)
-        if self.init:
-            self.iconview.select_path(Gtk.TreePath.new_first())
-            self.init = False
+        if prjname not in self._projects:
+            self._projects.append(prjname)
+            self.liststore.append([pixbuf, prjname])
+            #self.resize(64, len(self._projects) * 64)
+            if self.init:
+                from manager import PictonodeManager
+                self.iconview.select_path(Gtk.TreePath.new_first())
+                PictonodeManager().set_current_project(self.liststore[self.iconview.get_selected_items()[0]][1])
+                self.init = False
 
     def remove_project(self, prjname: str) -> None:
         remove_index = self._projects.index(prjname)
         self._projects.pop(remove_index)
         iter = self.liststore.get_iter((remove_index,))
         self.liststore.remove(iter)
-        self.resize(64, len(self._projects) * 64)
+        #self.resize(64, len(self._projects) * 64)
     
     def update_project_thumbnail(self, prjname: str, pixbuf: Pixbuf) -> None:
         if prjname in self._projects:

--- a/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/window.py
+++ b/gimp/pictonode-gimp-plugin/GIMP 2.99/pictonode/window.py
@@ -470,6 +470,7 @@ class PluginWindow(Gtk.Window):
                 print(E)
 
             self.node_view.show_all()
+            self.set_layers(self.layers)
 
             open_dialog.destroy()
             f.close()


### PR DESCRIPTION
## Segfault
@parkern342 was reporting semi-consistently segfaulting on the `Open Node Graph` callback, and that was smelling like a race condition.
https://github.com/notgull/pictonode/blob/7541bff232a81c967e21eab6c0b47b61c5690f20/gimp/pictonode-gimp-plugin/GIMP%202.99/pictonode/window.py#L444-L449

Originally thought it had to do with the  `open_dialog.get_filename()` and `open_dialog.destroy()` in the middle of the callback, but after testing this specifically it had no effect, which makes sense as callbacks are executed atomically in the main thread, effectively blocking and leaving no chance for the properties to be nullified yet until after the callback, not to mention any function that returns a `str` is [guaranteed to do so.](https://python-gtk-3-tutorial.readthedocs.io/en/latest/unicode.html#unicode-in-gtk)

That left `node.destroy()`. [Gtk.Widget.destroy](https://docs.gtk.org/gtk3/method.Widget.destroy.html) here, since this `Open Node Graph` callback is blocking, effectively queues up all node destroy events at once, and from what I can gather from [here](https://refspecs.linuxbase.org/gtk/2.6/gtk/gtk-Signals.html#enum%20GtkSignalRunTypel) and [here](https://www.linuxtopia.org/online_books/gui_toolkit_guides/gtk+_gnome_application_development/z109_3.html), subsequenting signal emissions from destroy() can have their execution order depend on some execution behavior enums. I think that since `GtkNodes.Node`(s) have circular references to one another via sockets, there may be implicit code dependencies in the way of signal execution order, and I think what's happening is some `g_signal_emit` is failing a `g_type_check_instance` via a libc assert, due to the destroy signal coming from the "bottom" (an individual node), which may screw up other internal `GtkNodes.Node`(s) states in regard to signals, as we're failing on a signal emit array:

```
/usr/lib/x86_64-linux-gnu/libc.so.6(+0x3f0c0)[0x7f633a6cf0c0]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_type_check_instance+0x1d)[0x7f63396f2afd]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_signal_emit_valist+0x3f)[0x7f63396e723f]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_signal_emit+0x93)[0x7f63396e8363]
```

<details><summary>stacktrace</summary>
<pre><code>/home/stehfyn/.var/app/org.gimp.GIMP/config/GIMP/2.99/plug-ins/pictonode/pictonode.py (pid:76): [E]xit, show [S]tack trace or [P]roceed: S
/app/lib/libgimpbase-3.0.so.0(gimp_stack_trace_print+0x427)[0x7f6334bfd5d7]
/app/lib/libgimpbase-3.0.so.0(gimp_stack_trace_query+0x10f)[0x7f6334bfd9cf]
/app/lib/libgimp-3.0.so.0(+0x218e2)[0x7f6334c388e2]
/usr/lib/x86_64-linux-gnu/libc.so.6(+0x3f0c0)[0x7f633a6cf0c0]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_type_check_instance+0x1d)[0x7f63396f2afd]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_signal_emit_valist+0x3f)[0x7f63396e723f]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_signal_emit+0x93)[0x7f63396e8363]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(+0x1770a)[0x7f63396cc70a]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_signal_emit_valist+0xf5f)[0x7f63396e815f]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_signal_emit+0x93)[0x7f63396e8363]
/home/stehfyn/.var/app/org.gimp.GIMP/config/GIMP/2.99/plug-ins/pictonode/libs/libgtknodes-0.1.so.0(+0x7d47)[0x7f63361e7d47]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_closure_invoke+0x172)[0x7f63396cc4f2]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(+0x2c280)[0x7f63396e1280]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_signal_emit_valist+0xf95)[0x7f63396e8195]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_signal_emit+0x93)[0x7f63396e8363]
/usr/lib/x86_64-linux-gnu/libgtk-3.so.0(+0x377cfe)[0x7f6335b06cfe]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_object_unref+0x141)[0x7f63396d1bd1]
/usr/lib/python3.10/site-packages/gi/_gi.cpython-310-x86_64-linux-gnu.so(+0x1862e)[0x7f63398b762e]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x1978b5)[0x7f633aa348b5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0xae4c5)[0x7f633a94b4c5]
/usr/lib/python3.10/site-packages/gi/_gi.cpython-310-x86_64-linux-gnu.so(+0x183d5)[0x7f63398b73d5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0xbff26)[0x7f633a95cf26]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0xc07cd)[0x7f633a95d7cd]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0xc09e5)[0x7f633a95d9e5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyObject_GC_New+0x17)[0x7f633a95da47]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(PyWrapper_New+0x1d)[0x7f633a95db9d]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x13b320)[0x7f633a9d8320]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x16dfa5)[0x7f633aa0afa5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(PyObject_GetAttr+0x4d)[0x7f633a9eb1bd]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyEval_EvalFrameDefault+0x2b03)[0x7f633a90d733]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x1c62e5)[0x7f633aa632e5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyEval_EvalFrameDefault+0x6406)[0x7f633a911036]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x1c62e5)[0x7f633aa632e5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyEval_EvalFrameDefault+0x6406)[0x7f633a911036]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x1c62e5)[0x7f633aa632e5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyEval_EvalFrameDefault+0x6406)[0x7f633a911036]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x1c62e5)[0x7f633aa632e5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyEval_EvalFrameDefault+0x6406)[0x7f633a911036]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x1c62e5)[0x7f633aa632e5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyObject_FastCallDictTstate+0x69)[0x7f633a9d5429]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyObject_Call_Prepend+0xff)[0x7f633a9d571f]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x16e285)[0x7f633aa0b285]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x1260c2)[0x7f633a9c30c2]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyObject_MakeTpCall+0x9c)[0x7f633a9d52ac]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyEval_EvalFrameDefault+0x784b)[0x7f633a91247b]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x1c62e5)[0x7f633aa632e5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyEval_EvalFrameDefault+0x672a)[0x7f633a91135a]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x1c62e5)[0x7f633aa632e5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x13fade)[0x7f633a9dcade]
/usr/lib/python3.10/site-packages/gi/_gi.cpython-310-x86_64-linux-gnu.so(+0x3266a)[0x7f63398d166a]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_closure_invoke+0x172)[0x7f63396cc4f2]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(+0x2c1e8)[0x7f63396e11e8]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_signal_emit_valist+0xf95)[0x7f63396e8195]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_signal_emit+0x93)[0x7f63396e8363]
/usr/lib/x86_64-linux-gnu/libgtk-3.so.0(gtk_widget_activate+0x5c)[0x7f6335aff47c]
/usr/lib/x86_64-linux-gnu/libgtk-3.so.0(gtk_menu_shell_activate_item+0x146)[0x7f63359b84a6]
/usr/lib/x86_64-linux-gnu/libgtk-3.so.0(+0x22977b)[0x7f63359b877b]
/usr/lib/x86_64-linux-gnu/libgtk-3.so.0(+0xa6bd7)[0x7f6335835bd7]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(+0x1770a)[0x7f63396cc70a]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_signal_emit_valist+0x39e)[0x7f63396e759e]
/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(g_signal_emit+0x93)[0x7f63396e8363]
/usr/lib/x86_64-linux-gnu/libgtk-3.so.0(+0x36d704)[0x7f6335afc704]
/usr/lib/x86_64-linux-gnu/libgtk-3.so.0(+0x212d70)[0x7f63359a1d70]
/usr/lib/x86_64-linux-gnu/libgtk-3.so.0(gtk_main_do_event+0x6e6)[0x7f63359a38e6]
/usr/lib/x86_64-linux-gnu/libgdk-3.so.0(+0x42bc1)[0x7f6337253bc1]
/usr/lib/x86_64-linux-gnu/libgdk-3.so.0(+0x9fa6e)[0x7f63372b0a6e]
/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0(g_main_context_dispatch+0x191)[0x7f63397ae681]
/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0(+0x5bbd8)[0x7f63397aebd8]
/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0(g_main_loop_run+0x7f)[0x7f63397aeebf]
/usr/lib/x86_64-linux-gnu/libgtk-3.so.0(gtk_main+0x85)[0x7f63359a2a45]
/usr/lib/x86_64-linux-gnu/libffi.so.8(+0x9056)[0x7f63396ae056]
/usr/lib/x86_64-linux-gnu/libffi.so.8(+0x7add)[0x7f63396acadd]
/usr/lib/x86_64-linux-gnu/libffi.so.8(ffi_call+0x123)[0x7f63396ad2b3]
/usr/lib/python3.10/site-packages/gi/_gi.cpython-310-x86_64-linux-gnu.so(+0x33696)[0x7f63398d2696]
/usr/lib/python3.10/site-packages/gi/_gi.cpython-310-x86_64-linux-gnu.so(+0x35571)[0x7f63398d4571]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyObject_Call+0x66)[0x7f633a9daaa6]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyEval_EvalFrameDefault+0x506c)[0x7f633a90fc9c]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x1c62e5)[0x7f633aa632e5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyEval_EvalFrameDefault+0x8b8e)[0x7f633a9137be]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x1c62e5)[0x7f633aa632e5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyEval_EvalFrameDefault+0x6406)[0x7f633a911036]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x1c62e5)[0x7f633aa632e5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x13fade)[0x7f633a9dcade]
/usr/lib/python3.10/site-packages/gi/_gi.cpython-310-x86_64-linux-gnu.so(+0x30b62)[0x7f63398cfb62]
/usr/lib/x86_64-linux-gnu/libffi.so.8(+0x8642)[0x7f63396ad642]
/usr/lib/x86_64-linux-gnu/libffi.so.8(+0x9278)[0x7f63396ae278]
/app/lib/libgimp-3.0.so.0(+0x28785)[0x7f6334c3f785]
/app/lib/libgimp-3.0.so.0(gimp_procedure_run+0x147)[0x7f6334c49707]
/app/lib/libgimp-3.0.so.0(+0x2e23e)[0x7f6334c4523e]
/app/lib/libgimp-3.0.so.0(_gimp_plug_in_run+0xf4)[0x7f6334c45d14]
/app/lib/libgimp-3.0.so.0(gimp_main+0x61d)[0x7f6334c38fbd]
/usr/lib/x86_64-linux-gnu/libffi.so.8(+0x9056)[0x7f63396ae056]
/usr/lib/x86_64-linux-gnu/libffi.so.8(+0x7add)[0x7f63396acadd]
/usr/lib/x86_64-linux-gnu/libffi.so.8(ffi_call+0x123)[0x7f63396ad2b3]
/usr/lib/python3.10/site-packages/gi/_gi.cpython-310-x86_64-linux-gnu.so(+0x33696)[0x7f63398d2696]
/usr/lib/python3.10/site-packages/gi/_gi.cpython-310-x86_64-linux-gnu.so(+0x35571)[0x7f63398d4571]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyObject_MakeTpCall+0x9c)[0x7f633a9d52ac]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(_PyEval_EvalFrameDefault+0x8be1)[0x7f633a913811]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(+0x1c62e5)[0x7f633aa632e5]
/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0(PyEval_EvalCode+0x96)[0x7f633aa63956]
/home/stehfyn/.var/app/org.gimp.GIMP/config/GIMP/2.99/plug-ins/pictonode/pictonode.py (pid:76): [E]xit, show [S]tack trace or [P]roceed: </code></pre></details>

Switched to:
```python
for node in self.node_view.get_children():
    # Calls  NodeView.remove() that looks like it handles circular widget reference counts from sockets
    self.node_view.remove(node)
```
and have been unable to reproduce a segfault from manual tests.

## Userstate awareness
It's intentional that accessing GIMP UI objects is actively restricted, which presents an issue for us as a persistent process. Ideally we could just override the `Gdk.EventType` a  `Gtk.Widget` can receive if we wanted to lock the `GimpIcon` widget that allows a user to remove a `Gimp.Image` from memory for example, but we realistically can only ever get the `Gdk.Window` handle of the parent window(s) and from there we'd have to iterate over the `gsignals` and figure even more out dynamically. Therefore the alternative is we just now poll:
```python

def run(self):
    GLib.timeout_add(1000, self.__update)

    self.set_gtk_theme()

    self.toolbar.show_all()
    self.main_window.show_all()

    Gtk.main()
    
def __update(self):
    try:
        added, removed = self.__update_xcf_image_association()
        self.__propagate_xcf_image_association_changes(added, removed)

        if self.init_layers and (len(self.images_with_xcf) > 0):
            self.init_layers = False
            print("set layers init")
            print(self.images_with_xcf[0].list_layers())
            self.main_window.set_layers(self.images_with_xcf[0].list_layers())      

    except Exception as e:
         print(e)
    #return true to keep __update in Gtk.main() idle execution list
    return True
```
This is far from a finished implementation, and @parkern342 and I got to whiteboard some things out, but the general idea is we can't ever guarantee the state of a GIMP api call, so we gotta come up with some ways to defensively code against it (large delta time) and not have unexpected behavior. I did some placeholder modifications to `window.py` and `custom_nodes.py` and we now have gui elements aware of a current xcf (not quite pictonode projects but definitely on approach):

https://user-images.githubusercontent.com/67705843/225515714-e21a8fde-b34d-4932-93b5-f25f87c97b8d.mp4

#### Known issues
- Toolbar doesn't auto select after removal
- NodeView doesn't save layer lists on project change
- Layer deltas aren't yet scanned for, you have to toggle between projects to get node view aware of new layers
